### PR TITLE
Only enable formatting on IRC connections

### DIFF
--- a/pidgin-irc-format.c
+++ b/pidgin-irc-format.c
@@ -168,7 +168,10 @@ plugin_load(PurplePlugin *plugin)
 	conns = purple_connections_get_all();
 	for(; conns; conns = conns->next)
 	{
-		ircformat_enable_formatting_on_connection(conns->data);
+		PurpleConnection *pc = conns->data;
+		if (!g_str_equal(pc->account->protocol_id, "prpl-irc"))
+			continue;
+		ircformat_enable_formatting_on_connection(pc);
 	}
 
 	return TRUE;
@@ -182,7 +185,10 @@ plugin_unload(PurplePlugin *plugin)
 	conns = purple_connections_get_all();
 	for(; conns; conns = conns->next)
 	{
-		ircformat_disable_formatting_on_connection(conns->data);
+		PurpleConnection *pc = conns->data;
+		if (!g_str_equal(pc->account->protocol_id, "prpl-irc"))
+			continue;
+		ircformat_disable_formatting_on_connection(pc);
 	}
 
 	return TRUE;


### PR DESCRIPTION
There was a long-standing problem with the plugin that I never fixed which was that it would enable formatting on all protocols, even if they didn't support it, rather than just on IRC and IRC conversations.
